### PR TITLE
hashfix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+0.2.3 - 2017/01/12
+----------------------
+feat: support repath inline assets src
+
 0.2.2 - 2016/8/26
 ----------------------
 feat: support .htm files

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The plugin accepts the following options:
 - regx: must be instance of RegExp
 - replace: must be a function return new path of html
 - ignore: pass through to glob
+- hashFix: fix atool-build assets hash repath
 - xFixAssets: do not fix assets paths in html but fix hash
-- hash: fix assets with hash paths in html 
+- hash: fix assets with hash paths in html
 - forceRelative: absolute path in html would regard as relative, USED FOR publicPath
 
 ### License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-repath-webpack-plugin",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "manage html output path by this plugin",
   "main": "index.js",
   "scripts": {

--- a/src/hashReplace.js
+++ b/src/hashReplace.js
@@ -1,0 +1,15 @@
+import { filsMap, fixAssetsInHtml } from './util';
+function hashReplace(compiler) {
+  compiler.plugin('compilation', (compilation) => {
+    const assets = compilation.assets;
+    let map = {};
+    compilation.plugin('html-webpack-plugin-after-html-processing', (htmlData, callback) => {
+      const htmlPluginData = htmlData;
+      map = filsMap(assets);
+      htmlPluginData.html = fixAssetsInHtml(htmlPluginData.html, '', map, true, false);
+      callback(null, htmlPluginData);
+    });
+  });
+}
+
+export default hashReplace;

--- a/src/util.js
+++ b/src/util.js
@@ -56,3 +56,22 @@ export function isValidReplace(replace) {
 
   return isValid;
 }
+
+export function filesMap(assets) {
+  let map = {};
+  if (!assets) {
+    return map;
+  }
+  map = Object.keys(assets).reduce((prev, item) => {
+    const _prev = prev;
+    const pathInfo = parse(item);
+    const spInfo = pathInfo.name.split('-');
+    const extname = pathInfo.ext;
+    const hash = spInfo[1];
+    const name = spInfo[0];
+    _prev[name + extname] = hash;
+
+    return _prev;
+  }, {});
+  return map;
+}

--- a/test/expect/with-hashFix.html
+++ b/test/expect/with-hashFix.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="common.js"></script>
+    <link rel="stylesheet" type="text/css" href="common.css">
+    <script src="index.js"></script>
+    <link rel="stylesheet" type="text/css" href="index.css">
+  </head>
+<body>
+  <h1 class="gear-1">gear-1-test</h1>
+</body>
+</html>

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import rimraf from 'rimraf';
 import compile from './utils/compile';
 import HtmlRepathPlugin from '../src';
-import { isValidExpression, isValidReplace } from '../src/util';
+import { isValidExpression, isValidReplace, filesMap } from '../src/util';
 
 const fixDir = join(__dirname, 'fixtures');
 const expDir = join(__dirname, 'expect');
@@ -124,6 +124,22 @@ describe('HtmlRepathPlugin', () => {
       });
   });
 
+  it('with params: hashFix', done => {
+    // 需要补充更详细的用例
+    compile(
+      new HtmlRepathPlugin({
+        hashFix: true,
+        hash: true,
+      }), true, () => {
+        const now = readFileSync(join(tmpDir, 'x/x/x/index.html'), 'utf-8');
+        const path = join(expDir, 'with-hashFix.html');
+        const exp = readFileSync(path, 'utf-8');
+        expect(now).to.equal(exp);
+        done();
+      });
+    done();
+  });
+
   it('util with invalid regx', done => {
     expect(isValidExpression).withArgs('*,djla$/').to.throwError();
     done();
@@ -131,6 +147,18 @@ describe('HtmlRepathPlugin', () => {
 
   it('util with invalid replace', done => {
     expect(isValidReplace).withArgs('*,djla$/').to.throwError();
+    done();
+  });
+
+  it('util with filesMap', done => {
+    const arg = {
+      'test-abc.js': {},
+      'check-abc.css': {},
+      'aaa.html': '',
+    };
+    expect(filesMap('')).to.eql({});
+    const result = expect(filesMap(arg));
+    result.to.have.property('test.js', 'abc');
     done();
   });
 });


### PR DESCRIPTION
把 `atool-build --hash` 后 html 内静态文件 path 替换为带有 hash 的 path

用户的使用方法

```
webpackConfig.plugins.push(new HtmlRepathPlugin({
    hashFix: true,
  }));
```